### PR TITLE
KB-12830 | Regression: Learner Portal > Advanced Assessment > Assessment Score is not showing for advanced assessment with fill in the blank type of question.

### DIFF
--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
@@ -1026,7 +1026,8 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 						break;
 					case Constants.FTB:
 						for (Map<String, Object> option : options) {
-							if ((boolean) option.get(Constants.ANSWER)) {
+							if ((option.get(Constants.ANSWER) instanceof Boolean boolValue && boolValue) ||
+									(option.get(Constants.ANSWER) instanceof String)) {
 								Map<String, Object> valueObj = mapper.convertValue(option.get(Constants.VALUE), new TypeReference<Map<String, Object>>() {
 								});
 								String answerText = valueObj.get(Constants.BODY).toString();


### PR DESCRIPTION

1. option.get(ANSWER) can be string or boolean.