### PR TITLE
KB-12937 | KB-12114 | "Complete previous milestone assessment" error is being thrown when trying to consume a second milestone even after completing the first milestone's assessment

### DIFF
--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
@@ -1653,9 +1653,9 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 			Constants.USER_ID_CONSTANT,
 			Constants.COURSE_ID,
 			Constants.BATCH_ID,
-			Constants.LANG_CONTENT_STATUS,
+			Constants.LANG_CONTENT_STATUS_KEY,
 			Constants.ACTIVE,
-			Constants.RECENT_LANGUAGE
+			Constants.RECENT_LANGUAGE_KEY
 		);
 		return cassandraOperation.getRecordsByPropertiesWithoutFiltering(
 				Constants.KEYSPACE_SUNBIRD_COURSES,

--- a/src/main/java/com/igot/cb/common/util/Constants.java
+++ b/src/main/java/com/igot/cb/common/util/Constants.java
@@ -1383,6 +1383,8 @@ public class Constants {
     public static final String ASSESSMENT_ID_REPLACER = "{assessmentId}";
     public static final String LEARNING_PATHWAY = "Learning Pathway";
     public static final String PRELIMINARY_ASSESSMENT = "preliminaryAssessment";
+    public static final String LANG_CONTENT_STATUS_KEY = "lang_contentstatus";
+    public static final String RECENT_LANGUAGE_KEY = "recent_language";
 
     private Constants() {
         throw new IllegalStateException("Utility class");


### PR DESCRIPTION

1. Querying to the cassandra with wrong keys.