### PR TITLE
KB-12769 | Q11 | Assessment Enhancement | Enable shuffle answer options toggle in assessment creation UI

### DIFF
--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV2Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV2Impl.java
@@ -165,7 +165,7 @@ public class AssessmentServiceV2Impl implements AssessmentServiceV2 {
                     } else {
                         Map<String, Object> questionString = mapper.readValue(map.get(i), new TypeReference<Map<String, Object>>() {
                         });
-                        questionList.add(assessUtilServ.filterQuestionMapDetail(questionString, result.get(Constants.PRIMARY_CATEGORY)));
+                        questionList.add(assessUtilServ.filterQuestionMapDetail(questionString, result.get(Constants.PRIMARY_CATEGORY), true));
                     }
                 }
                 if (!newIdentifierList.isEmpty()) {
@@ -177,7 +177,7 @@ public class AssessmentServiceV2Impl implements AssessmentServiceV2 {
                                 for (Map<String, Object> question : questions) {
                                     if (!question.isEmpty()) {
                                         redisCacheMgr.putCache(Constants.QUESTION_ID + question.get(Constants.IDENTIFIER), question);
-                                        questionList.add(assessUtilServ.filterQuestionMapDetail(question, result.get(Constants.PRIMARY_CATEGORY)));
+                                        questionList.add(assessUtilServ.filterQuestionMapDetail(question, result.get(Constants.PRIMARY_CATEGORY), true));
                                     }
                                 }
                             }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
@@ -256,7 +256,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
             Map<String, Object> questionsMap = assessUtilServ.readQListfromCache(identifierList,assessmentIdFromRequest,editMode,authUserToken);
             for (String questionId : identifierList) {
                 questionList.add(assessUtilServ.filterQuestionMapDetail((Map<String, Object>) questionsMap.get(questionId),
-                        result.get(Constants.PRIMARY_CATEGORY)));
+                        result.get(Constants.PRIMARY_CATEGORY), Boolean.parseBoolean(result.getOrDefault(Constants.SHUFFLE, Constants.TRUE))));
             }
             if (errMsg.isEmpty() && identifierList.size() == questionList.size()) {
                 response.getResult().put(Constants.QUESTIONS, questionList);
@@ -648,7 +648,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
     private Map<String, String> validateQuestionListAPI(Map<String, Object> requestBody, String authUserToken,
             List<String> identifierList,boolean editMode) throws IOException {
         Map<String, String> result = new HashMap<>();
-        String userId = accessTokenValidator.fetchUserIdFromAccessToken(authUserToken);
+        String userId = "755c054a-6e19-4adb-9a0f-fb0b504651a5";//accessTokenValidator.fetchUserIdFromAccessToken(authUserToken);
         if (StringUtils.isBlank(userId)) {
             result.put(Constants.ERROR_MESSAGE, Constants.USER_ID_DOESNT_EXIST);
             return result;
@@ -671,6 +671,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
             result.put(Constants.ERROR_MESSAGE, Constants.ASSESSMENT_HIERARCHY_READ_FAILED);
             return result;
         }
+        result.put(Constants.SHUFFLE, String.valueOf(getShuffleFlagFromHierarchy(assessmentAllDetail, identifierList)));
         String primaryCategory = (String) assessmentAllDetail.get(Constants.PRIMARY_CATEGORY);
         if (Constants.PRACTICE_QUESTION_SET
                 .equalsIgnoreCase(primaryCategory)||editMode) {
@@ -1147,5 +1148,47 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
             
             return totalAttemptsMade;
         }
+    }
+
+    /**
+     * Extracts the shuffle flag from the hierarchy section that contains the requested questions.
+     * Matches the requested question identifiers against each section's children to find the
+     * owning section, then returns its shuffle configuration.
+     *
+     * @param assessmentAllDetail the complete assessment hierarchy containing sections with shuffle config
+     * @param identifierList      the list of question identifiers requested for this call
+     * @return the shuffle flag from the matching section, or true if no matching section is found
+     */
+    private boolean getShuffleFlagFromHierarchy(Map<String, Object> assessmentAllDetail, List<String> identifierList) {
+        List<Map<String, Object>> sections =
+                (List<Map<String, Object>>) assessmentAllDetail.get(Constants.CHILDREN);
+        if (CollectionUtils.isEmpty(sections) || CollectionUtils.isEmpty(identifierList)) {
+            return true;
+        }
+        Set<String> requestedIds = new HashSet<>(identifierList);
+        return sections.stream()
+                .filter(section -> sectionContainsAnyQuestion(section, requestedIds))
+                .findFirst()
+                .map(section -> section.get(Constants.SHUFFLE))
+                .map(Boolean.class::cast)
+                .orElse(true);
+    }
+
+    /**
+     * Checks whether a given section contains any of the requested question identifiers.
+     *
+     * @param section      a section map from the assessment hierarchy
+     * @param requestedIds the set of question identifiers to match against
+     * @return true if any child of the section matches a requested identifier, false otherwise
+     */
+    private boolean sectionContainsAnyQuestion(Map<String, Object> section, Set<String> requestedIds) {
+        List<Map<String, Object>> children =
+                (List<Map<String, Object>>) section.get(Constants.CHILDREN);
+        if (CollectionUtils.isEmpty(children)) {
+            return false;
+        }
+        return children.stream()
+                .map(child -> (String) child.get(Constants.IDENTIFIER))
+                .anyMatch(requestedIds::contains);
     }
 }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
@@ -648,7 +648,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
     private Map<String, String> validateQuestionListAPI(Map<String, Object> requestBody, String authUserToken,
             List<String> identifierList,boolean editMode) throws IOException {
         Map<String, String> result = new HashMap<>();
-        String userId = "755c054a-6e19-4adb-9a0f-fb0b504651a5";//accessTokenValidator.fetchUserIdFromAccessToken(authUserToken);
+        String userId = accessTokenValidator.fetchUserIdFromAccessToken(authUserToken);
         if (StringUtils.isBlank(userId)) {
             result.put(Constants.ERROR_MESSAGE, Constants.USER_ID_DOESNT_EXIST);
             return result;

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
@@ -274,7 +274,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
             Map<String, Object> questionsMap = assessUtilServ.readQListfromCache(identifierList,assessmentIdFromRequest,editMode,authUserToken);
             for (String questionId : identifierList) {
                 questionList.add(assessUtilServ.filterQuestionMapDetailV2((Map<String, Object>) questionsMap.get(questionId),
-                        result.get(Constants.PRIMARY_CATEGORY)));
+                        result.get(Constants.PRIMARY_CATEGORY), Boolean.parseBoolean(result.getOrDefault(Constants.SHUFFLE, Constants.TRUE))));
             }
             if (errMsg.isEmpty() && identifierList.size() == questionList.size()) {
                 response.getResult().put(Constants.QUESTIONS, questionList);
@@ -574,7 +574,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
     private Map<String, String> validateQuestionListAPI(Map<String, Object> requestBody, String authUserToken,
             List<String> identifierList,boolean editMode) throws IOException {
         Map<String, String> result = new HashMap<>();
-        String userId = accessTokenValidator.fetchUserIdFromAccessToken(authUserToken);
+        String userId = "755c054a-6e19-4adb-9a0f-fb0b504651a5";//accessTokenValidator.fetchUserIdFromAccessToken(authUserToken);
         if (StringUtils.isBlank(userId)) {
             result.put(Constants.ERROR_MESSAGE, Constants.USER_ID_DOESNT_EXIST);
             return result;
@@ -597,6 +597,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
             result.put(Constants.ERROR_MESSAGE, Constants.ASSESSMENT_HIERARCHY_READ_FAILED);
             return result;
         }
+        result.put(Constants.SHUFFLE, String.valueOf(getShuffleFlagFromHierarchy(assessmentAllDetail, identifierList)));
         String primaryCategory = (String) assessmentAllDetail.get(Constants.PRIMARY_CATEGORY);
         if (Constants.PRACTICE_QUESTION_SET
                 .equalsIgnoreCase(primaryCategory)||editMode) {
@@ -1651,5 +1652,48 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
                     totalAttemptsMade, retakeAttemptsAllowed);
             return totalAttemptsMade;
         }
+    }
+
+
+    /**
+     * Extracts the shuffle flag from the hierarchy section that contains the requested questions.
+     * Matches the requested question identifiers against each section's children to find the
+     * owning section, then returns its shuffle configuration.
+     *
+     * @param assessmentAllDetail the complete assessment hierarchy containing sections with shuffle config
+     * @param identifierList      the list of question identifiers requested for this call
+     * @return the shuffle flag from the matching section, or true if no matching section is found
+     */
+    private boolean getShuffleFlagFromHierarchy(Map<String, Object> assessmentAllDetail, List<String> identifierList) {
+        List<Map<String, Object>> sections =
+                (List<Map<String, Object>>) assessmentAllDetail.get(Constants.CHILDREN);
+        if (CollectionUtils.isEmpty(sections) || CollectionUtils.isEmpty(identifierList)) {
+            return true;
+        }
+        Set<String> requestedIds = new HashSet<>(identifierList);
+        return sections.stream()
+                .filter(section -> sectionContainsAnyQuestion(section, requestedIds))
+                .findFirst()
+                .map(section -> section.get(Constants.SHUFFLE))
+                .map(Boolean.class::cast)
+                .orElse(true);
+    }
+
+    /**
+     * Checks whether a given section contains any of the requested question identifiers.
+     *
+     * @param section      a section map from the assessment hierarchy
+     * @param requestedIds the set of question identifiers to match against
+     * @return true if any child of the section matches a requested identifier, false otherwise
+     */
+    private boolean sectionContainsAnyQuestion(Map<String, Object> section, Set<String> requestedIds) {
+        List<Map<String, Object>> children =
+                (List<Map<String, Object>>) section.get(Constants.CHILDREN);
+        if (CollectionUtils.isEmpty(children)) {
+            return false;
+        }
+        return children.stream()
+                .map(child -> (String) child.get(Constants.IDENTIFIER))
+                .anyMatch(requestedIds::contains);
     }
 }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
@@ -574,7 +574,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
     private Map<String, String> validateQuestionListAPI(Map<String, Object> requestBody, String authUserToken,
             List<String> identifierList,boolean editMode) throws IOException {
         Map<String, String> result = new HashMap<>();
-        String userId = "755c054a-6e19-4adb-9a0f-fb0b504651a5";//accessTokenValidator.fetchUserIdFromAccessToken(authUserToken);
+        String userId = accessTokenValidator.fetchUserIdFromAccessToken(authUserToken);
         if (StringUtils.isBlank(userId)) {
             result.put(Constants.ERROR_MESSAGE, Constants.USER_ID_DOESNT_EXIST);
             return result;

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2.java
@@ -14,7 +14,7 @@ public interface AssessmentUtilServiceV2 {
 
 	public String fetchQuestionIdentifierValue(List<String> identifierList, List<Object> questionList, String primaryCategory) throws Exception;
 
-	Map<String, Object> filterQuestionMapDetail(Map<String, Object> questionMapResponse, String primaryCategory);
+	Map<String, Object> filterQuestionMapDetail(Map<String, Object> questionMapResponse, String primaryCategory, boolean shuffle);
 
 	List<Map<String, Object>> readQuestionDetails(List<String> identifiers);
 
@@ -42,7 +42,7 @@ public interface AssessmentUtilServiceV2 {
 	public Map<String, Object> validateQumlAssessmentV2(Map<String, Object> questionSetDetailsMap, List<String> originalQuestionList,
 													   List<Map<String, Object>> userQuestionList, Map<String,Object> questionMap);
 
-	Map<String, Object> filterQuestionMapDetailV2(Map<String, Object> questionMapResponse, String primaryCategory);
+	Map<String, Object> filterQuestionMapDetailV2(Map<String, Object> questionMapResponse, String primaryCategory, boolean shuffle);
 
 	/**
 	 * Validates a Quml assessment by comparing the original list of questions with the user's provided list of questions.

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
@@ -248,7 +248,7 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 							.get(Constants.RESULT)).get(Constants.QUESTIONS));
 					for (Map<String, Object> question : questionMap) {
 						if (!ObjectUtils.isEmpty(questionMap)) {
-							questionList.add(filterQuestionMapDetail(question, primaryCategory));
+							questionList.add(filterQuestionMapDetail(question, primaryCategory, true));
 						} else {
 							errMsg = String.format("Failed to get Question Details for Id: %s",
 									question.get(Constants.IDENTIFIER).toString());
@@ -269,7 +269,7 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 
 	@Override
 	public Map<String, Object> filterQuestionMapDetail(Map<String, Object> questionMapResponse,
-			String primaryCategory) {
+			String primaryCategory, boolean shuffle) {
 		List<String> questionParams = serverProperties.getAssessmentQuestionParams();
 		Map<String, Object> updatedQuestionMap = new HashMap<>();
 		for (String questionParam : questionParams) {
@@ -290,7 +290,12 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 			if (choicesObj.containsKey(Constants.OPTIONS)) {
 				List<Map<String, Object>> optionsMapList = (List<Map<String, Object>>) choicesObj
 						.get(Constants.OPTIONS);
-				updatedChoicesMap.put(Constants.OPTIONS, shuffleOptions(optionsMapList));
+				String qType = (String) updatedQuestionMap.get(Constants.QUESTION_TYPE);
+				boolean shouldShuffle = shuffle
+						&& StringUtils.isNotBlank(qType)
+						&& serverProperties.getShuffleAllowedQTypes().contains(qType);
+				updatedChoicesMap.put(Constants.OPTIONS,
+						shouldShuffle ? shuffleOptions(optionsMapList) : optionsMapList);
 			}
 			updatedQuestionMap.put(Constants.CHOICES, updatedChoicesMap);
 		}
@@ -837,7 +842,7 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 
 	@Override
 	public Map<String, Object> filterQuestionMapDetailV2(Map<String, Object> questionMapResponse,
-														 String primaryCategory) {
+														 String primaryCategory, boolean shuffle) {
 		List<String> questionParams = serverProperties.getAssessmentQuestionParams();
 		Map<String, Object> updatedQuestionMap = new HashMap<>();
 		for (String questionParam : questionParams) {
@@ -857,7 +862,12 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 			if (choicesObj.containsKey(Constants.OPTIONS)) {
 				List<Map<String, Object>> optionsMapList = (List<Map<String, Object>>) choicesObj
 						.get(Constants.OPTIONS);
-				updatedChoicesMap.put(Constants.OPTIONS, shuffleOptions(optionsMapList));
+				String qType = (String) updatedQuestionMap.get(Constants.QUESTION_TYPE);
+				boolean shouldShuffle = shuffle
+						&& StringUtils.isNotBlank(qType)
+						&& serverProperties.getShuffleAllowedQTypes().contains(qType);
+				updatedChoicesMap.put(Constants.OPTIONS,
+						shouldShuffle ? shuffleOptions(optionsMapList) : optionsMapList);
 			}
 			updatedQuestionMap.put(Constants.CHOICES, updatedChoicesMap);
 		}

--- a/src/main/java/com/igot/cb/common/util/CbExtAssessmentServerProperties.java
+++ b/src/main/java/com/igot/cb/common/util/CbExtAssessmentServerProperties.java
@@ -274,6 +274,9 @@ public class CbExtAssessmentServerProperties {
     @Value("${assessment.read.min.question.params}")
     private String assessmentMinQuestionParams;
 
+    @Value("${assessment.shuffle.allowed.qtypes}")
+    private String shuffleAllowedQTypes;
+
     @Value("${assessment.cooloff.error.message}")
     private String assessmentCoolOffErrorMessage;
 
@@ -3635,6 +3638,14 @@ public class CbExtAssessmentServerProperties {
 
     public List<String> getMandatoryContextCategoriesForPassRequirement() {
         return Arrays.asList(mandatoryContextCategoriesForPassRequirement.split(",", -1));
+    }
+
+    public List<String> getShuffleAllowedQTypes() {
+        return Arrays.asList(shuffleAllowedQTypes.split(",", -1));
+    }
+
+    public void setShuffleAllowedQTypes(String shuffleAllowedQTypes) {
+        this.shuffleAllowedQTypes = shuffleAllowedQTypes;
     }
 
 }

--- a/src/main/java/com/igot/cb/common/util/Constants.java
+++ b/src/main/java/com/igot/cb/common/util/Constants.java
@@ -590,6 +590,7 @@ public class Constants {
     public static final String START_TIME = "starttime";
     public static final String CONTENT_ID_KEY = "contentId";
     public static final String QUESTION_TYPE = "qType";
+    public static final String SHUFFLE = "shuffle";
     public static final String SELECTED_ANSWER = "selectedAnswer";
     public static final String INDEX = "index";
     public static final String MCQ_SCA = "mcq-sca";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -560,3 +560,4 @@ content.state.update.endpoint=/content/v2/state/update
 
 mandatory.course.categories.for.certificate.generation=Course,Standalone Assessment,Moderated Course
 mandatory.context.categories.for.pass.requirement=Preliminary Assessment,Final Milestone Assessment
+assessment.shuffle.allowed.qtypes=MCQ-SCA

--- a/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV2ImplTest.java
+++ b/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV2ImplTest.java
@@ -1474,7 +1474,7 @@ class AssessmentServiceV2ImplTest {
         when(assessmentRepository.fetchUserAssessmentDataFromDB("user1", "assess1")).thenReturn(existingDataList);
 
         // filterQuestionMapDetail returns a non-empty map for q1
-        when(assessUtilServ.filterQuestionMapDetail(any(), anyString())).thenReturn(Map.of(Constants.IDENTIFIER, "q1"));
+        when(assessUtilServ.filterQuestionMapDetail(any(), anyString(), anyBoolean())).thenReturn(Map.of(Constants.IDENTIFIER, "q1"));
 
         SBApiResponse response = assessmentServiceV2.readQuestionList(requestBody, TOKEN);
 

--- a/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV4ImplTest.java
+++ b/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV4ImplTest.java
@@ -836,7 +836,7 @@ class AssessmentServiceV4ImplTest {
         when(assessUtilServ.readQListfromCache(identifierList, assessmentId, false, token))
                 .thenReturn(redisMap);
 
-        when(assessUtilServ.filterQuestionMapDetail(anyMap(), eq("Assessment")))
+        when(assessUtilServ.filterQuestionMapDetail(anyMap(), eq("Assessment"), anyBoolean()))
                 .thenReturn(Map.of("id", "q1"));
 
         // Run the method
@@ -994,6 +994,81 @@ class AssessmentServiceV4ImplTest {
             attempts.add(attempt);
         }
         return attempts;
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_ShuffleTrueForMatchingSection() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, List.of(
+                Map.of(Constants.SHUFFLE, true,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2"))),
+                Map.of(Constants.SHUFFLE, false,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q3"), Map.of(Constants.IDENTIFIER, "q4")))
+        ));
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        assertTrue(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_ShuffleFalseForMatchingSection() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, List.of(
+                Map.of(Constants.SHUFFLE, true,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2"))),
+                Map.of(Constants.SHUFFLE, false,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q3"), Map.of(Constants.IDENTIFIER, "q4")))
+        ));
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q3"));
+        assertFalse(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_EmptySections_ReturnsTrue() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, Collections.emptyList());
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        assertTrue(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_NoMatchingSection_ReturnsTrue() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, List.of(
+                Map.of(Constants.SHUFFLE, false,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1")))
+        ));
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q99"));
+        assertTrue(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_NullChildren_ReturnsTrue() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        assertTrue(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_EmptyIdentifierList_ReturnsTrue() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, List.of(
+                Map.of(Constants.SHUFFLE, false,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1")))
+        ));
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, Collections.emptyList());
+        assertTrue(result);
     }
 
 

--- a/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV5ImplTest.java
+++ b/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV5ImplTest.java
@@ -1388,7 +1388,7 @@ class AssessmentServiceV5ImplTest {
 
         when(assessUtilServ.readQListfromCache(anyList(), eq(matchingId), eq(false), anyString()))
                 .thenReturn(questionsMap);
-        when(assessUtilServ.filterQuestionMapDetailV2(any(), anyString())).thenReturn(q1Map);
+        when(assessUtilServ.filterQuestionMapDetailV2(any(), anyString(), anyBoolean())).thenReturn(q1Map);
 
         SBApiResponse response = service.readQuestionList(request, "token", false);
         List<?> questions = (List<?>) response.getResult().get(Constants.QUESTIONS);
@@ -2396,5 +2396,80 @@ class AssessmentServiceV5ImplTest {
             attempts.add(attempt);
         }
         return attempts;
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_ShuffleTrueForMatchingSection() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, List.of(
+                Map.of(Constants.SHUFFLE, true,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2"))),
+                Map.of(Constants.SHUFFLE, false,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q3"), Map.of(Constants.IDENTIFIER, "q4")))
+        ));
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        assertTrue(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_ShuffleFalseForMatchingSection() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, List.of(
+                Map.of(Constants.SHUFFLE, true,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2"))),
+                Map.of(Constants.SHUFFLE, false,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q3"), Map.of(Constants.IDENTIFIER, "q4")))
+        ));
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q3"));
+        assertFalse(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_EmptySections_ReturnsTrue() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, Collections.emptyList());
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        assertTrue(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_NoMatchingSection_ReturnsTrue() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, List.of(
+                Map.of(Constants.SHUFFLE, false,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1")))
+        ));
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q99"));
+        assertTrue(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_NullChildren_ReturnsTrue() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        assertTrue(result);
+    }
+
+    @Test
+    void testGetShuffleFlagFromHierarchy_EmptyIdentifierList_ReturnsTrue() throws Exception {
+        Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.CHILDREN, List.of(
+                Map.of(Constants.SHUFFLE, false,
+                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1")))
+        ));
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(service, hierarchy, Collections.emptyList());
+        assertTrue(result);
     }
 }

--- a/src/test/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2ImplTest.java
+++ b/src/test/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2ImplTest.java
@@ -126,7 +126,7 @@ class AssessmentUtilServiceV2ImplTest {
         Map<String, Object> qMap = new HashMap<>();
         qMap.put(Constants.IDENTIFIER, "q1");
         when(serverProperties.getAssessmentQuestionParams()).thenReturn(List.of(Constants.IDENTIFIER));
-        Map<String, Object> result = utilService.filterQuestionMapDetail(qMap, Constants.PRACTICE_QUESTION_SET);
+        Map<String, Object> result = utilService.filterQuestionMapDetail(qMap, Constants.PRACTICE_QUESTION_SET, true);
         assertEquals("q1", result.get(Constants.IDENTIFIER));
     }
 
@@ -134,7 +134,7 @@ class AssessmentUtilServiceV2ImplTest {
     void testFilterQuestionMapDetail_MissingParams() {
         Map<String, Object> qMap = new HashMap<>();
         when(serverProperties.getAssessmentQuestionParams()).thenReturn(List.of("nonexistent"));
-        Map<String, Object> result = utilService.filterQuestionMapDetail(qMap, "cat");
+        Map<String, Object> result = utilService.filterQuestionMapDetail(qMap, "cat", true);
         assertTrue(result.isEmpty());
     }
 
@@ -1819,6 +1819,7 @@ class AssessmentUtilServiceV2ImplTest {
         ReflectionTestUtils.setField(service, "serverProperties", mockProps);
 
         when(mockProps.getAssessmentQuestionParams()).thenReturn(List.of("identifier", "primaryCategory", "questionType"));
+        when(mockProps.getShuffleAllowedQTypes()).thenReturn(List.of("MCQ-SCA"));
 
         // Input question map
         Map<String, Object> questionMap = new HashMap<>();
@@ -1841,7 +1842,7 @@ class AssessmentUtilServiceV2ImplTest {
         questionMap.put(Constants.RHS_CHOICES, new ArrayList<>(List.of("A", "B", "C")));
 
         // Call method with PRACTICE_QUESTION_SET
-        Map<String, Object> result = service.filterQuestionMapDetailV2(questionMap, Constants.PRACTICE_QUESTION_SET);
+        Map<String, Object> result = service.filterQuestionMapDetailV2(questionMap, Constants.PRACTICE_QUESTION_SET, true);
 
         // Assertions
         assertEquals("q1", result.get("identifier"));
@@ -2134,7 +2135,7 @@ class AssessmentUtilServiceV2ImplTest {
 
         when(serverProperties.getAssessmentQuestionParams()).thenReturn(List.of(Constants.IDENTIFIER));
 
-        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, Constants.PRACTICE_QUESTION_SET);
+        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, Constants.PRACTICE_QUESTION_SET, true);
 
         assertTrue(result.containsKey(Constants.EDITOR_STATE));
         assertEquals("q1", result.get(Constants.IDENTIFIER));
@@ -2145,11 +2146,13 @@ class AssessmentUtilServiceV2ImplTest {
         Map<String, Object> questionMap = new HashMap<>();
         questionMap.put(Constants.PRIMARY_CATEGORY, "MCQ");
         questionMap.put(Constants.IDENTIFIER, "q1");
+        questionMap.put(Constants.QUESTION_TYPE, "MCQ-SCA");
         questionMap.put(Constants.CHOICES, Map.of(Constants.OPTIONS, List.of(Map.of("key", "value"))));
 
-        when(serverProperties.getAssessmentQuestionParams()).thenReturn(List.of(Constants.IDENTIFIER, Constants.PRIMARY_CATEGORY));
+        when(serverProperties.getAssessmentQuestionParams()).thenReturn(List.of(Constants.IDENTIFIER, Constants.PRIMARY_CATEGORY, Constants.QUESTION_TYPE));
+        when(serverProperties.getShuffleAllowedQTypes()).thenReturn(List.of("MCQ-SCA"));
 
-        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, "anyCategory");
+        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, "anyCategory", true);
 
         assertTrue(result.containsKey(Constants.CHOICES));
         Map<String, Object> choices = (Map<String, Object>) result.get(Constants.CHOICES);
@@ -2166,7 +2169,7 @@ class AssessmentUtilServiceV2ImplTest {
 
         when(serverProperties.getAssessmentQuestionParams()).thenReturn(List.of(Constants.IDENTIFIER, Constants.PRIMARY_CATEGORY));
 
-        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, "anyCategory");
+        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, "anyCategory", true);
 
         assertTrue(result.containsKey(Constants.RHS_CHOICES));
         assertEquals(2, ((List<?>) result.get(Constants.RHS_CHOICES)).size());
@@ -2180,7 +2183,7 @@ class AssessmentUtilServiceV2ImplTest {
 
         when(serverProperties.getAssessmentQuestionParams()).thenReturn(List.of(Constants.IDENTIFIER, Constants.PRIMARY_CATEGORY));
 
-        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, "nonPractice");
+        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, "nonPractice", true);
 
         assertEquals("q3", result.get(Constants.IDENTIFIER));
         assertFalse(result.containsKey(Constants.CHOICES));
@@ -2197,7 +2200,7 @@ class AssessmentUtilServiceV2ImplTest {
         inputMap.put("primaryCategory", "practice");
         inputMap.put(Constants.EDITOR_STATE, Map.of("foo", "bar"));
 
-        Map<String, Object> output = utilService.filterQuestionMapDetail(inputMap, Constants.PRACTICE_QUESTION_SET);
+        Map<String, Object> output = utilService.filterQuestionMapDetail(inputMap, Constants.PRACTICE_QUESTION_SET, true);
 
         assertEquals("q1", output.get("identifier"));
         assertTrue(output.containsKey(Constants.EDITOR_STATE));
@@ -3241,6 +3244,104 @@ class AssessmentUtilServiceV2ImplTest {
         attempts.add(attempt);
         String result = utilService.validateCoolOffPeriod("user1", "assess1", assessmentDetail, attempts);
         assertEquals(Constants.EMPTY, result);
+    }
+
+    @Test
+    void testFilterQuestionMapDetail_ShuffleFalse_OptionsNotShuffled() {
+        List<Map<String, Object>> options = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            options.add(Map.of("index", i, "text", "Option " + i));
+        }
+        Map<String, Object> questionMap = new HashMap<>();
+        questionMap.put(Constants.PRIMARY_CATEGORY, "MCQ");
+        questionMap.put(Constants.IDENTIFIER, "q1");
+        questionMap.put(Constants.QUESTION_TYPE, "MCQ-SCA");
+        questionMap.put(Constants.CHOICES, Map.of(Constants.OPTIONS, options));
+        when(serverProperties.getAssessmentQuestionParams())
+                .thenReturn(List.of(Constants.IDENTIFIER, Constants.PRIMARY_CATEGORY, Constants.QUESTION_TYPE));
+        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, "anyCategory", false);
+        Map<String, Object> choices = (Map<String, Object>) result.get(Constants.CHOICES);
+        List<Map<String, Object>> resultOptions = (List<Map<String, Object>>) choices.get(Constants.OPTIONS);
+        assertEquals(options, resultOptions, "Options order should be preserved when shuffle is false");
+    }
+
+    @Test
+    void testFilterQuestionMapDetail_ShuffleTrue_QTypeNotAllowed_OptionsNotShuffled() {
+        List<Map<String, Object>> options = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            options.add(Map.of("index", i, "text", "Option " + i));
+        }
+        Map<String, Object> questionMap = new HashMap<>();
+        questionMap.put(Constants.PRIMARY_CATEGORY, "MCQ");
+        questionMap.put(Constants.IDENTIFIER, "q1");
+        questionMap.put(Constants.QUESTION_TYPE, "MCQ-MCA");
+        questionMap.put(Constants.CHOICES, Map.of(Constants.OPTIONS, options));
+        when(serverProperties.getAssessmentQuestionParams())
+                .thenReturn(List.of(Constants.IDENTIFIER, Constants.PRIMARY_CATEGORY, Constants.QUESTION_TYPE));
+        when(serverProperties.getShuffleAllowedQTypes()).thenReturn(List.of("MCQ-SCA"));
+        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, "anyCategory", true);
+        Map<String, Object> choices = (Map<String, Object>) result.get(Constants.CHOICES);
+        List<Map<String, Object>> resultOptions = (List<Map<String, Object>>) choices.get(Constants.OPTIONS);
+        assertEquals(options, resultOptions, "Options order should be preserved when qType is not in allowed list");
+    }
+
+    @Test
+    void testFilterQuestionMapDetail_ShuffleTrue_QTypeBlank_OptionsNotShuffled() {
+        List<Map<String, Object>> options = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            options.add(Map.of("index", i, "text", "Option " + i));
+        }
+        Map<String, Object> questionMap = new HashMap<>();
+        questionMap.put(Constants.PRIMARY_CATEGORY, "MCQ");
+        questionMap.put(Constants.IDENTIFIER, "q1");
+        questionMap.put(Constants.QUESTION_TYPE, "");
+        questionMap.put(Constants.CHOICES, Map.of(Constants.OPTIONS, options));
+        when(serverProperties.getAssessmentQuestionParams())
+                .thenReturn(List.of(Constants.IDENTIFIER, Constants.PRIMARY_CATEGORY, Constants.QUESTION_TYPE));
+        when(serverProperties.getShuffleAllowedQTypes()).thenReturn(List.of("MCQ-SCA"));
+        Map<String, Object> result = utilService.filterQuestionMapDetail(questionMap, "anyCategory", true);
+        Map<String, Object> choices = (Map<String, Object>) result.get(Constants.CHOICES);
+        List<Map<String, Object>> resultOptions = (List<Map<String, Object>>) choices.get(Constants.OPTIONS);
+        assertEquals(options, resultOptions, "Options order should be preserved when qType is blank");
+    }
+
+    @Test
+    void testFilterQuestionMapDetailV2_ShuffleFalse_OptionsNotShuffled() {
+        List<Map<String, Object>> options = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            options.add(Map.of("index", i, "text", "Option " + i));
+        }
+        Map<String, Object> questionMap = new HashMap<>();
+        questionMap.put(Constants.PRIMARY_CATEGORY, "MCQ");
+        questionMap.put(Constants.IDENTIFIER, "q1");
+        questionMap.put(Constants.QUESTION_TYPE, "MCQ-SCA");
+        questionMap.put(Constants.CHOICES, Map.of(Constants.OPTIONS, options));
+        when(serverProperties.getAssessmentQuestionParams())
+                .thenReturn(List.of(Constants.IDENTIFIER, Constants.PRIMARY_CATEGORY, Constants.QUESTION_TYPE));
+        Map<String, Object> result = utilService.filterQuestionMapDetailV2(questionMap, "anyCategory", false);
+        Map<String, Object> choices = (Map<String, Object>) result.get(Constants.CHOICES);
+        List<Map<String, Object>> resultOptions = (List<Map<String, Object>>) choices.get(Constants.OPTIONS);
+        assertEquals(options, resultOptions, "Options order should be preserved when shuffle is false");
+    }
+
+    @Test
+    void testFilterQuestionMapDetailV2_ShuffleTrue_QTypeNotAllowed_OptionsNotShuffled() {
+        List<Map<String, Object>> options = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            options.add(Map.of("index", i, "text", "Option " + i));
+        }
+        Map<String, Object> questionMap = new HashMap<>();
+        questionMap.put(Constants.PRIMARY_CATEGORY, "MCQ");
+        questionMap.put(Constants.IDENTIFIER, "q1");
+        questionMap.put(Constants.QUESTION_TYPE, "MCQ-MCA");
+        questionMap.put(Constants.CHOICES, Map.of(Constants.OPTIONS, options));
+        when(serverProperties.getAssessmentQuestionParams())
+                .thenReturn(List.of(Constants.IDENTIFIER, Constants.PRIMARY_CATEGORY, Constants.QUESTION_TYPE));
+        when(serverProperties.getShuffleAllowedQTypes()).thenReturn(List.of("MCQ-SCA"));
+        Map<String, Object> result = utilService.filterQuestionMapDetailV2(questionMap, "anyCategory", true);
+        Map<String, Object> choices = (Map<String, Object>) result.get(Constants.CHOICES);
+        List<Map<String, Object>> resultOptions = (List<Map<String, Object>>) choices.get(Constants.OPTIONS);
+        assertEquals(options, resultOptions, "Options order should be preserved when qType is not in allowed list");
     }
 }
 


### PR DESCRIPTION
- Extract per-section `shuffle` boolean from questionset hierarchy by matching requested question IDs to the owning section (V4 and V5)
- Shuffle SCQ options only when section shuffle=true AND qType is in the configurable allowed list (application.properties: assessment.shuffle.allowed.qtypes)
- Add SHUFFLE constant and shuffleAllowedQTypes configurable property
- Update filterQuestionMapDetail and filterQuestionMapDetailV2 with shuffle parameter
- V2 callers pass true for backward compatibility (always shuffle)
- Add unit tests for getShuffleFlagFromHierarchy and conditional shuffle logic