### PR TITLE
Assessment Retake Error Message Fix (#65)

### DIFF
--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
@@ -103,9 +103,6 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
                     if (response.getResponseCode() == HttpStatus.BAD_REQUEST) {
                         return response;
                     }
-                    if (retakeAttemptsConsumed >= retakeAttemptsAllowed) {
-                        errMsg = Constants.ASSESSMENT_RETRY_ATTEMPTS_CROSSED;
-                    }
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
* Assessment Retake Error Message Fix

1. We will not be be sending the error message with 500 Internal server error message.
2. WIll send 200 ok with the count of retakeallowed and consumed attempts.

* Removed the error message being sent for the max attempts allowed.