### PR TITLE
KB-13220 | Audit all the Assessment Submit Requests failed post validation into a new cassandra table.

### DIFF
--- a/src/main/java/com/igot/cb/assessment/repo/AssessmentRepository.java
+++ b/src/main/java/com/igot/cb/assessment/repo/AssessmentRepository.java
@@ -38,17 +38,5 @@ public interface AssessmentRepository {
 
     List<Map<String, Object>> fetchUserAssessmentDataFromDB(String userId, String assessmentIdentifier);
 
-    /**
-     * Inserts a failed assessment audit record into the database for tracking and debugging purposes.
-     *
-     * @param userId        the ID of the user who attempted the assessment
-     * @param assessmentId  the identifier of the assessment that failed
-     * @param submitRequest the original submit request payload
-     * @param errMessage    the error message describing the failure
-     * @param methodName    the fully qualified method name where the failure occurred
-     * @return true if the audit record was inserted successfully, false otherwise
-     */
-    boolean addFailedAssessmentAudit(String userId, String assessmentId, Map<String, Object> submitRequest,
-                                     String errMessage, String methodName);
 
 }

--- a/src/main/java/com/igot/cb/assessment/repo/AssessmentRepository.java
+++ b/src/main/java/com/igot/cb/assessment/repo/AssessmentRepository.java
@@ -38,4 +38,17 @@ public interface AssessmentRepository {
 
     List<Map<String, Object>> fetchUserAssessmentDataFromDB(String userId, String assessmentIdentifier);
 
+    /**
+     * Inserts a failed assessment audit record into the database for tracking and debugging purposes.
+     *
+     * @param userId        the ID of the user who attempted the assessment
+     * @param assessmentId  the identifier of the assessment that failed
+     * @param submitRequest the original submit request payload
+     * @param errMessage    the error message describing the failure
+     * @param methodName    the fully qualified method name where the failure occurred
+     * @return true if the audit record was inserted successfully, false otherwise
+     */
+    boolean addFailedAssessmentAudit(String userId, String assessmentId, Map<String, Object> submitRequest,
+                                     String errMessage, String methodName);
+
 }

--- a/src/main/java/com/igot/cb/assessment/repo/AssessmentRepositoryImpl.java
+++ b/src/main/java/com/igot/cb/assessment/repo/AssessmentRepositoryImpl.java
@@ -180,4 +180,30 @@ public class AssessmentRepositoryImpl implements AssessmentRepository {
         return existingDataList;
     }
 
+    /**
+     * Inserts a failed assessment audit record into the database for tracking and debugging purposes.
+     * Builds an audit record with userId, assessmentId, current timestamp, failure status,
+     * error message, method name, and the serialized submit request payload,
+     * then inserts it into the {@code user_assessment_failed_audit} Cassandra table.
+     */
+    @Override
+    public boolean addFailedAssessmentAudit(String userId, String assessmentId, Map<String, Object> submitRequest,
+                                            String errMessage, String methodName) {
+        Map<String, Object> request = new HashMap<>();
+        request.put(Constants.USER_ID, userId);
+        request.put(Constants.ASSESSMENT_ID_KEY, assessmentId);
+        request.put(Constants.START_TIME, Instant.now());
+        request.put(Constants.STATUS, Constants.FAILED);
+        request.put(Constants.ERROR_MESSAGE, errMessage);
+        request.put(Constants.METHOD_NAME, methodName);
+        if (MapUtils.isNotEmpty(submitRequest)) {
+            request.put(Constants.SUBMIT_ASSESSMENT_REQUEST, new Gson().toJson(submitRequest));
+        }
+        SBApiResponse resp = cassandraOperation.insertRecord(Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_USER_ASSESSMENT_FAILED_AUDIT, request);
+        Map<String, Object> result = (resp == null) ? null : resp.getResult();
+        Object responseVal = MapUtils.isEmpty(result) ? null : result.get(Constants.DB_STATUS);
+        return Constants.SUCCESS.equalsIgnoreCase(Objects.toString(responseVal, null));
+    }
+
 }

--- a/src/main/java/com/igot/cb/assessment/repo/AssessmentRepositoryImpl.java
+++ b/src/main/java/com/igot/cb/assessment/repo/AssessmentRepositoryImpl.java
@@ -180,30 +180,4 @@ public class AssessmentRepositoryImpl implements AssessmentRepository {
         return existingDataList;
     }
 
-    /**
-     * Inserts a failed assessment audit record into the database for tracking and debugging purposes.
-     * Builds an audit record with userId, assessmentId, current timestamp, failure status,
-     * error message, method name, and the serialized submit request payload,
-     * then inserts it into the {@code user_assessment_failed_audit} Cassandra table.
-     */
-    @Override
-    public boolean addFailedAssessmentAudit(String userId, String assessmentId, Map<String, Object> submitRequest,
-                                            String errMessage, String methodName) {
-        Map<String, Object> request = new HashMap<>();
-        request.put(Constants.USER_ID, userId);
-        request.put(Constants.ASSESSMENT_ID_KEY, assessmentId);
-        request.put(Constants.START_TIME, Instant.now());
-        request.put(Constants.STATUS, Constants.FAILED);
-        request.put(Constants.ERROR_MESSAGE, errMessage);
-        request.put(Constants.METHOD_NAME, methodName);
-        if (MapUtils.isNotEmpty(submitRequest)) {
-            request.put(Constants.SUBMIT_ASSESSMENT_REQUEST, new Gson().toJson(submitRequest));
-        }
-        SBApiResponse resp = cassandraOperation.insertRecord(Constants.KEYSPACE_SUNBIRD,
-                Constants.TABLE_USER_ASSESSMENT_FAILED_AUDIT, request);
-        Map<String, Object> result = (resp == null) ? null : resp.getResult();
-        Object responseVal = MapUtils.isEmpty(result) ? null : result.get(Constants.DB_STATUS);
-        return Constants.SUCCESS.equalsIgnoreCase(Objects.toString(responseVal, null));
-    }
-
 }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 
 import java.io.IOException;
-import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -32,6 +31,7 @@ import java.util.stream.Collectors;
 import static com.igot.cb.common.util.Constants.RESPONSE;
 import static com.igot.cb.common.util.ProjectUtil.createDefaultResponse;
 import static java.util.stream.Collectors.toList;
+import com.igot.cb.core.exception.ApplicationLogicError;
 
 @Service
 @SuppressWarnings("unchecked")
@@ -455,6 +455,8 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
             String errMsg = String.format("Failed to process assessment submit request. Exception: ", e.getMessage());
             logger.error(errMsg, e);
             updateErrorDetails(outgoingResponse, errMsg, HttpStatus.INTERNAL_SERVER_ERROR);
+            assessmentRepository.addFailedAssessmentAudit((String) submitRequest.get(Constants.USER_ID),
+                    (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V4_SUBMIT_ASSESSMENT_ASYNC);
         }
         return outgoingResponse;
     }
@@ -857,7 +859,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
     }
 
     public Map<String, Object> createResponseMapWithProperStructure(Map<String, Object> hierarchySection,
-            Map<String, Object> resultMap) {
+                                                                    Map<String, Object> resultMap) throws ApplicationLogicError {
         Map<String, Object> sectionLevelResult = new HashMap<>();
         sectionLevelResult.put(Constants.IDENTIFIER, hierarchySection.get(Constants.IDENTIFIER));
         sectionLevelResult.put(Constants.OBJECT_TYPE, hierarchySection.get(Constants.OBJECT_TYPE));
@@ -887,7 +889,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
         return sectionLevelResult;
     }
 
-    private Map<String, Object> calculateAssessmentFinalResults(Map<String, Object> assessmentLevelResult) {
+    private Map<String, Object> calculateAssessmentFinalResults(Map<String, Object> assessmentLevelResult) throws ApplicationLogicError {
         Map<String, Object> res = new HashMap<>();
         try {
             res.put(Constants.CHILDREN, Collections.singletonList(assessmentLevelResult));
@@ -907,8 +909,8 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
     }
 
     private void writeDataToDatabaseAndTriggerKafkaEvent(Map<String, Object> submitRequest, String userId,
-            Map<String, Object> questionSetFromAssessment, Map<String, Object> result, String primaryCategory,String courseCategory,
-                                                         String userAuthToken, boolean shouldUpdateContentProgress, String contextCategory ) {
+                                                         Map<String, Object> questionSetFromAssessment, Map<String, Object> result, String primaryCategory, String courseCategory,
+                                                         String userAuthToken, boolean shouldUpdateContentProgress, String contextCategory) throws ApplicationLogicError {
         try {
             if (questionSetFromAssessment.get(Constants.START_TIME) != null) {
                 Instant startTime = assessUtilServ.parseStartTimeToInstant(questionSetFromAssessment.get(Constants.START_TIME));
@@ -959,7 +961,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
         }
     }
 
-    private Map<String, Object> calculateSectionFinalResults(List<Map<String, Object>> sectionLevelResults) {
+    private Map<String, Object> calculateSectionFinalResults(List<Map<String, Object>> sectionLevelResults) throws ApplicationLogicError {
         Map<String, Object> res = new HashMap<>();
         Double result;
         Integer correct = 0;

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
@@ -456,7 +456,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
             logger.error(errMsg, e);
             updateErrorDetails(outgoingResponse, errMsg, HttpStatus.INTERNAL_SERVER_ERROR);
             assessUtilServ.publishFailedAssessmentAuditEvent((String) submitRequest.get(Constants.USER_ID),
-                    (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V4_SUBMIT_ASSESSMENT_ASYNC);
+                    (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V4_SUBMIT_ASSESSMENT_ASYNC, outgoingResponse.getResult());
         }
         return outgoingResponse;
     }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
@@ -455,7 +455,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
             String errMsg = String.format("Failed to process assessment submit request. Exception: ", e.getMessage());
             logger.error(errMsg, e);
             updateErrorDetails(outgoingResponse, errMsg, HttpStatus.INTERNAL_SERVER_ERROR);
-            assessmentRepository.addFailedAssessmentAudit((String) submitRequest.get(Constants.USER_ID),
+            assessUtilServ.publishFailedAssessmentAuditEvent((String) submitRequest.get(Constants.USER_ID),
                     (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V4_SUBMIT_ASSESSMENT_ASYNC);
         }
         return outgoingResponse;

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
@@ -12,6 +12,7 @@ import com.igot.cb.common.service.OutboundRequestHandlerServiceImpl;
 import com.igot.cb.common.util.AccessTokenValidator;
 import com.igot.cb.common.util.CbExtAssessmentServerProperties;
 import com.igot.cb.common.util.Constants;
+import com.igot.cb.core.exception.ApplicationLogicError;
 import com.igot.cb.core.producer.Producer;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -491,6 +492,8 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
             String errMsg = String.format("Failed to process assessment submit request. Exception: ", e.getMessage());
             logger.error(errMsg, e);
             updateErrorDetails(outgoingResponse, errMsg, HttpStatus.INTERNAL_SERVER_ERROR);
+            assessmentRepository.addFailedAssessmentAudit((String) submitRequest.get(Constants.USER_ID),
+                    (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V5_SUBMIT_ASSESSMENT_ASYNC);
         }
         return outgoingResponse;
     }
@@ -780,7 +783,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
     }
 
     public Map<String, Object> createResponseMapWithProperStructure(Map<String, Object> hierarchySection,
-            Map<String, Object> resultMap, Integer assessmentMinimumPassPercentage) {
+                                                                    Map<String, Object> resultMap, Integer assessmentMinimumPassPercentage) throws ApplicationLogicError {
         Map<String, Object> sectionLevelResult = new HashMap<>();
         sectionLevelResult.put(Constants.IDENTIFIER, hierarchySection.get(Constants.IDENTIFIER));
         sectionLevelResult.put(Constants.OBJECT_TYPE, hierarchySection.get(Constants.OBJECT_TYPE));
@@ -821,7 +824,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
         return sectionLevelResult;
     }
 
-    private Map<String, Object> calculateAssessmentFinalResults(Map<String, Object> assessmentLevelResult) {
+    private Map<String, Object> calculateAssessmentFinalResults(Map<String, Object> assessmentLevelResult) throws ApplicationLogicError {
         Map<String, Object> res = new HashMap<>();
         try {
             res.put(Constants.CHILDREN, Collections.singletonList(assessmentLevelResult));
@@ -842,7 +845,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
     }
 
     private void writeDataToDatabaseAndTriggerKafkaEvent(Map<String, Object> submitRequest, String userId,
-                                                         Map<String, Object> questionSetFromAssessment, Map<String, Object> result, String primaryCategory, String courseCategory, String userAuthToken,String contextCategory) {
+                                                         Map<String, Object> questionSetFromAssessment, Map<String, Object> result, String primaryCategory, String courseCategory, String userAuthToken, String contextCategory) throws ApplicationLogicError {
         try {
             if (questionSetFromAssessment.get(Constants.START_TIME) != null) {
                 Instant startTime = assessUtilServ.parseStartTimeToInstant(questionSetFromAssessment.get(Constants.START_TIME));
@@ -892,7 +895,8 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
         }
     }
 
-    private Map<String, Object> calculateSectionFinalResults(List<Map<String, Object>> sectionLevelResults, long assessmentStartTime, long assessmentCompletionTime, int maxAssessmentRetakeAttempts, int retakeAttemptsConsumed) {
+    private Map<String, Object> calculateSectionFinalResults(List<Map<String, Object>> sectionLevelResults, long assessmentStartTime, long assessmentCompletionTime, int maxAssessmentRetakeAttempts, int retakeAttemptsConsumed)
+            throws ApplicationLogicError {
         Map<String, Object> res = new HashMap<>();
         Double result;
         Integer correct = 0;
@@ -1006,7 +1010,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
      * @return a map containing the parameter details for the question types.
      * @throws IOException if there is an error processing the question section schema.
      */
-    private Map<String, Object> getParamDetailsForQTypes(Map<String, Object> hierarchySection,Map<String, Object> assessmentHierarchy,String hierarchySectionId) throws IOException {
+    private Map<String, Object> getParamDetailsForQTypes(Map<String, Object> hierarchySection,Map<String, Object> assessmentHierarchy,String hierarchySectionId) throws ApplicationLogicError {
         logger.info("Starting getParamDetailsForQTypes with assessmentHierarchy: {}", assessmentHierarchy);
         Map<String, Object> questionSetDetailsMap = new HashMap<>();
         String assessmentType = (String) assessmentHierarchy.get(Constants.ASSESSMENT_TYPE);
@@ -1495,6 +1499,8 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
             String errMsg = String.format("Failed to process assessment submit request. Exception: ", e.getMessage());
             logger.error(errMsg, e);
             updateErrorDetails(outgoingResponse, errMsg, HttpStatus.INTERNAL_SERVER_ERROR);
+            assessmentRepository.addFailedAssessmentAudit((String) submitRequest.get(Constants.USER_ID),
+                    (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V5_SUBMIT_ASSESSMENT_ASYNC_V6);
         }
         return outgoingResponse;
     }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
@@ -493,7 +493,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
             logger.error(errMsg, e);
             updateErrorDetails(outgoingResponse, errMsg, HttpStatus.INTERNAL_SERVER_ERROR);
             assessUtilServ.publishFailedAssessmentAuditEvent((String) submitRequest.get(Constants.USER_ID),
-                    (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V5_SUBMIT_ASSESSMENT_ASYNC);
+                    (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V5_SUBMIT_ASSESSMENT_ASYNC, outgoingResponse.getResult());
         }
         return outgoingResponse;
     }
@@ -1500,7 +1500,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
             logger.error(errMsg, e);
             updateErrorDetails(outgoingResponse, errMsg, HttpStatus.INTERNAL_SERVER_ERROR);
             assessUtilServ.publishFailedAssessmentAuditEvent((String) submitRequest.get(Constants.USER_ID),
-                    (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V5_SUBMIT_ASSESSMENT_ASYNC_V6);
+                    (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V5_SUBMIT_ASSESSMENT_ASYNC_V6, outgoingResponse.getResult());
         }
         return outgoingResponse;
     }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
@@ -492,7 +492,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
             String errMsg = String.format("Failed to process assessment submit request. Exception: ", e.getMessage());
             logger.error(errMsg, e);
             updateErrorDetails(outgoingResponse, errMsg, HttpStatus.INTERNAL_SERVER_ERROR);
-            assessmentRepository.addFailedAssessmentAudit((String) submitRequest.get(Constants.USER_ID),
+            assessUtilServ.publishFailedAssessmentAuditEvent((String) submitRequest.get(Constants.USER_ID),
                     (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V5_SUBMIT_ASSESSMENT_ASYNC);
         }
         return outgoingResponse;
@@ -1499,7 +1499,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
             String errMsg = String.format("Failed to process assessment submit request. Exception: ", e.getMessage());
             logger.error(errMsg, e);
             updateErrorDetails(outgoingResponse, errMsg, HttpStatus.INTERNAL_SERVER_ERROR);
-            assessmentRepository.addFailedAssessmentAudit((String) submitRequest.get(Constants.USER_ID),
+            assessUtilServ.publishFailedAssessmentAuditEvent((String) submitRequest.get(Constants.USER_ID),
                     (String) submitRequest.get(Constants.IDENTIFIER), submitRequest, errMsg, Constants.METHOD_V5_SUBMIT_ASSESSMENT_ASYNC_V6);
         }
         return outgoingResponse;

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2.java
@@ -105,4 +105,17 @@ public interface AssessmentUtilServiceV2 {
 	int calculateCyclicalRetakeAttempts(String userId, String assessmentIdentifier,
 										Map<String, Object> assessmentAllDetail,
 										List<Map<String, Object>> userAssessmentDataList);
+
+	/**
+	 * Publishes a failed assessment audit event to a Kafka error topic for monitoring purposes.
+	 * No consumer is attached to this topic — events are retained for future log dump/analysis.
+	 *
+	 * @param userId        the user identifier
+	 * @param assessmentId  the assessment identifier
+	 * @param submitRequest the original submit request payload
+	 * @param errMessage    the error message describing the failure
+	 * @param methodName    the method name where the failure occurred
+	 */
+	void publishFailedAssessmentAuditEvent(String userId, String assessmentId,
+										   Map<String, Object> submitRequest, String errMessage, String methodName);
 }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2.java
@@ -117,5 +117,6 @@ public interface AssessmentUtilServiceV2 {
 	 * @param methodName    the method name where the failure occurred
 	 */
 	void publishFailedAssessmentAuditEvent(String userId, String assessmentId,
-										   Map<String, Object> submitRequest, String errMessage, String methodName);
+										   Map<String, Object> submitRequest, String errMessage, String methodName,
+										   Map<String, Object> submitAssessmentResponse);
 }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2.java
@@ -2,6 +2,7 @@ package com.igot.cb.assessment.service;
 
 
 import com.igot.cb.common.model.SBApiResponse;
+import com.igot.cb.core.exception.ApplicationLogicError;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -10,7 +11,7 @@ import java.util.Map;
 
 public interface AssessmentUtilServiceV2 {
 	public Map<String, Object> validateQumlAssessment(List<String> originalQuestionList,
-													  List<Map<String, Object>> userQuestionList,Map<String,Object> questionMap);
+													  List<Map<String, Object>> userQuestionList, Map<String, Object> questionMap) throws ApplicationLogicError;
 
 	public String fetchQuestionIdentifierValue(List<String> identifierList, List<Object> questionList, String primaryCategory) throws Exception;
 
@@ -53,8 +54,8 @@ public interface AssessmentUtilServiceV2 {
 	 * @param questionMap           a map containing additional question-related information.
 	 * @return a map with validation results and resultMap.
 	 */
-	 Map<String, Object> validateQumlAssessmentV3(Map<String, Object> questionSetDetailsMap, List<String> originalQuestionList,
-														List<Map<String, Object>> userQuestionList, Map<String,Object> questionMap);
+	Map<String, Object> validateQumlAssessmentV3(Map<String, Object> questionSetDetailsMap, List<String> originalQuestionList,
+												 List<Map<String, Object>> userQuestionList, Map<String, Object> questionMap) throws ApplicationLogicError;
 
 	String validateContextLocking(Map<String, Object> assessmentAllDetail, String parentContextId,
 								  SBApiResponse response, String userId, String assessmentIdentifier);
@@ -67,7 +68,7 @@ public interface AssessmentUtilServiceV2 {
 
 	String readContentRecord(String courseId, List<String> fields);
 
-    String validateAssessmentLanguageAndNodes(Map<String, Object> submitRequest);
+    String validateAssessmentLanguageAndNodes(Map<String, Object> submitRequest) throws ApplicationLogicError;
 
 	/**
 	 * Checks if cool-off period is configured and valid for an assessment.

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
@@ -9,6 +9,7 @@ import com.igot.cb.common.service.ContentService;
 import com.igot.cb.common.service.OutboundRequestHandlerServiceImpl;
 import com.igot.cb.common.util.CbExtAssessmentServerProperties;
 import com.igot.cb.common.util.Constants;
+import com.igot.cb.core.exception.ApplicationLogicError;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
@@ -55,7 +56,7 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 	ContentService contentService;
 
 	public Map<String, Object> validateQumlAssessment(List<String> originalQuestionList,
-													  List<Map<String, Object>> userQuestionList,Map<String,Object> questionMap) {
+													  List<Map<String, Object>> userQuestionList, Map<String, Object> questionMap) throws ApplicationLogicError {
 		try {
 			Integer correct = 0;
 			Integer blank = 0;
@@ -891,7 +892,7 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 	 * @return a map with validation results and resultMap.
 	 */
 	public Map<String, Object> validateQumlAssessmentV3(Map<String, Object> questionSetDetailsMap, List<String> originalQuestionList,
-														List<Map<String, Object>> userQuestionList, Map<String, Object> questionMap) {
+														List<Map<String, Object>> userQuestionList, Map<String, Object> questionMap) throws ApplicationLogicError {
 		try {
 			String assessmentType = getAssessmentType(questionSetDetailsMap);
 			int minimumPassPercentage = getMinimumPassPercentage(questionSetDetailsMap);
@@ -946,9 +947,8 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 			computeSectionResults(sectionMarks, totalMarks, minimumPassPercentage, resultMap);
 			return resultMap;
 		} catch (Exception ex) {
-			logger.error("Error when verifying assessment. Error : ", ex);
+			throw new ApplicationLogicError("Error when verifying assessment: " + ex.getMessage(), ex);
 		}
-		return new HashMap<>();
 	}
 
 	/**
@@ -1299,7 +1299,7 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 	}
 
     @Override
-    public String validateAssessmentLanguageAndNodes(Map<String, Object> submitRequest) {
+	public String validateAssessmentLanguageAndNodes(Map<String, Object> submitRequest) throws ApplicationLogicError {
         logger.info("Validating assessment language and nodes for request: {}", submitRequest);
         try {
             String assessmentLanguageReq = (String) submitRequest.get(Constants.LANGUAGE);

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
@@ -2034,7 +2034,8 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 	 */
 	@Override
 	public void publishFailedAssessmentAuditEvent(String userId, String assessmentId,
-												   Map<String, Object> submitRequest, String errMessage, String methodName) {
+												   Map<String, Object> submitRequest, String errMessage, String methodName,
+												   Map<String, Object> submitAssessmentResponse) {
 		try {
 			Map<String, Object> event = new HashMap<>();
 			event.put(Constants.USER_ID, userId);
@@ -2045,6 +2046,9 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 			event.put(Constants.START_TIME, Instant.now().toString());
 			if (MapUtils.isNotEmpty(submitRequest)) {
 				event.put(Constants.SUBMIT_ASSESSMENT_REQUEST, submitRequest);
+			}
+			if (MapUtils.isNotEmpty(submitAssessmentResponse)) {
+				event.put(Constants.SUBMIT_ASSESSMENT_RESPONSE, submitAssessmentResponse);
 			}
 			String eventJson = mapper.writeValueAsString(event);
 			kafkaProducer.push(serverProperties.getAssessmentFailedAuditErrorTopic(), eventJson);

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2Impl.java
@@ -10,6 +10,7 @@ import com.igot.cb.common.service.OutboundRequestHandlerServiceImpl;
 import com.igot.cb.common.util.CbExtAssessmentServerProperties;
 import com.igot.cb.common.util.Constants;
 import com.igot.cb.core.exception.ApplicationLogicError;
+import com.igot.cb.core.producer.Producer;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
@@ -54,6 +55,9 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 
 	@Autowired
 	ContentService contentService;
+
+	@Autowired
+	Producer kafkaProducer;
 
 	public Map<String, Object> validateQumlAssessment(List<String> originalQuestionList,
 													  List<Map<String, Object>> userQuestionList, Map<String, Object> questionMap) throws ApplicationLogicError {
@@ -2012,5 +2016,42 @@ public class AssessmentUtilServiceV2Impl implements AssessmentUtilServiceV2 {
 			currentCycleCount++;
 		}
 		return currentCycleCount;
+	}
+
+	/**
+	 * Publishes a failed assessment audit event to a Kafka error topic.
+	 * <p>
+	 * Constructs an event payload containing the user ID, assessment ID, error message,
+	 * originating method name, status, timestamp, and optionally the original submit request.
+	 * The event is serialized to JSON and pushed to the configured Kafka error topic for audit purposes.
+	 * Any exception during publishing is logged without propagation to the caller.
+	 *
+	 * @param userId        the ID of the user who submitted the assessment
+	 * @param assessmentId  the ID of the assessment that failed
+	 * @param submitRequest the original assessment submit request payload (may be null or empty)
+	 * @param errMessage    the error message describing the failure reason
+	 * @param methodName    the name of the method where the failure originated
+	 */
+	@Override
+	public void publishFailedAssessmentAuditEvent(String userId, String assessmentId,
+												   Map<String, Object> submitRequest, String errMessage, String methodName) {
+		try {
+			Map<String, Object> event = new HashMap<>();
+			event.put(Constants.USER_ID, userId);
+			event.put(Constants.ASSESSMENT_ID_KEY, assessmentId);
+			event.put(Constants.ERROR_MESSAGE, errMessage);
+			event.put(Constants.METHOD_NAME, methodName);
+			event.put(Constants.STATUS, Constants.FAILED);
+			event.put(Constants.START_TIME, Instant.now().toString());
+			if (MapUtils.isNotEmpty(submitRequest)) {
+				event.put(Constants.SUBMIT_ASSESSMENT_REQUEST, submitRequest);
+			}
+			String eventJson = mapper.writeValueAsString(event);
+			kafkaProducer.push(serverProperties.getAssessmentFailedAuditErrorTopic(), eventJson);
+			logger.info("Published failed assessment audit event to Kafka error topic for userId: {}, assessmentId: {}", userId, assessmentId);
+		} catch (Exception e) {
+			logger.error("Failed to publish failed assessment audit event to Kafka. UserId: {}, AssessmentId: {}, Exception: {}",
+					userId, assessmentId, e.getMessage(), e);
+		}
 	}
 }

--- a/src/main/java/com/igot/cb/common/service/ContentService.java
+++ b/src/main/java/com/igot/cb/common/service/ContentService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.igot.cb.common.model.SBApiResponse;
+import com.igot.cb.core.exception.ApplicationLogicError;
 
 public interface ContentService {
     Object getContentType(String parentId);
@@ -17,7 +18,7 @@ public interface ContentService {
 
     public Set<String> readChildCoursesFromCache(String parentDoId);
 
-    public Map<String, Object> readContent(String contentId);
+    public Map<String, Object> readContent(String contentId) throws ApplicationLogicError;
 
     String updatePreEnrolledAssessment(String userAuthToken, Map<String, Object> submitRequest, String userId, SBApiResponse contentUpdateResponse);
 }

--- a/src/main/java/com/igot/cb/common/service/ContentServiceImpl.java
+++ b/src/main/java/com/igot/cb/common/service/ContentServiceImpl.java
@@ -6,6 +6,7 @@ import com.igot.cb.cache.RedisCacheMgr;
 import com.igot.cb.common.model.SBApiResponse;
 import com.igot.cb.common.util.CbExtAssessmentServerProperties;
 import com.igot.cb.common.util.Constants;
+import com.igot.cb.core.exception.ApplicationLogicError;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -69,7 +70,7 @@ public class ContentServiceImpl implements ContentService{
     }
 
     @Override
-    public String updateContentProgress(String userAuthToken, Map<String, Object> reqBody, String userId, SBApiResponse outgoingResponse) {
+    public String updateContentProgress(String userAuthToken, Map<String, Object> reqBody, String userId, SBApiResponse outgoingResponse) throws ApplicationLogicError {
         String response = "";
         try {
             Map<String, String> headers = new HashMap<>();
@@ -180,12 +181,12 @@ public class ContentServiceImpl implements ContentService{
 
         return responseData;
     }
-    public Map<String, Object> readContent(String contentId) {
+    public Map<String, Object> readContent(String contentId) throws ApplicationLogicError {
         return readContent(contentId, Collections.emptyList());
     }
 
     @Override
-    public String updatePreEnrolledAssessment(String userAuthToken, Map<String, Object> reqBody, String userId, SBApiResponse outgoingResponse) {
+    public String updatePreEnrolledAssessment(String userAuthToken, Map<String, Object> reqBody, String userId, SBApiResponse outgoingResponse) throws ApplicationLogicError {
         String response = "";
         try {
             Map<String, String> headers = new HashMap<>();
@@ -234,7 +235,7 @@ public class ContentServiceImpl implements ContentService{
         return response;
     }
 
-    public Map<String, Object> readContent(String contentId, List<String> fields) {
+    public Map<String, Object> readContent(String contentId, List<String> fields) throws ApplicationLogicError {
         StringBuilder url = new StringBuilder();
         url.append(serverConfig.getContentHost()).append(serverConfig.getContentReadEndPoint()).append("/" + contentId)
                 .append(serverConfig.getContentReadEndPointFields());

--- a/src/main/java/com/igot/cb/common/util/CbExtAssessmentServerProperties.java
+++ b/src/main/java/com/igot/cb/common/util/CbExtAssessmentServerProperties.java
@@ -1083,6 +1083,9 @@ public class CbExtAssessmentServerProperties {
     @Value("${assessment.learningpathway.assessment.notfound.error}")
     private String assessmentLearningPathwayAssessmentNotFoundError;
 
+    @Value("${kafka.topics.assessment.failed.audit.error}")
+    private String assessmentFailedAuditErrorTopic;
+
     public String getStateLearningInsightsRedisKeyMapping() {
         return stateLearningInsightsRedisKeyMapping;
     }

--- a/src/main/java/com/igot/cb/common/util/Constants.java
+++ b/src/main/java/com/igot/cb/common/util/Constants.java
@@ -1386,7 +1386,15 @@ public class Constants {
     public static final String PRELIMINARY_ASSESSMENT = "preliminaryAssessment";
     public static final String LANG_CONTENT_STATUS_KEY = "lang_contentstatus";
     public static final String RECENT_LANGUAGE_KEY = "recent_language";
-
+    public static final String METHOD_NAME = "methodname";
+    public static final String SUBMIT_ASSESSMENT_REQUEST = "submitassessmentrequest";
+    public static final String DB_STATUS = "STATUS";
+    public static final String METHOD_V4_SUBMIT_ASSESSMENT_ASYNC = "AssessmentServiceV4Impl.submitAssessmentAsync";
+    public static final String METHOD_V4_HANDLE_ASSESSMENT_SUBMIT_REQUEST = "AssessmentServiceV4Impl.handleAssessmentSubmitRequest";
+    public static final String METHOD_V5_SUBMIT_ASSESSMENT_ASYNC = "AssessmentServiceV5Impl.submitAssessmentAsync";
+    public static final String METHOD_V5_SUBMIT_ASSESSMENT_ASYNC_V6 = "AssessmentServiceV5Impl.submitAssessmentAsyncV6";
+    public static final String TABLE_USER_ASSESSMENT_FAILED_AUDIT = "user_assessment_failed_audit";
+    
     private Constants() {
         throw new IllegalStateException("Utility class");
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -561,3 +561,6 @@ content.state.update.endpoint=/content/v2/state/update
 mandatory.course.categories.for.certificate.generation=Course,Standalone Assessment,Moderated Course
 mandatory.context.categories.for.pass.requirement=Preliminary Assessment,Final Milestone Assessment
 assessment.shuffle.allowed.qtypes=MCQ-SCA
+
+#Failed assessment audit error topic (no consumer - for monitoring/log dump only)
+kafka.topics.assessment.failed.audit.error=dev.assessment.failed.audit.error

--- a/src/test/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2ImplTest.java
+++ b/src/test/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2ImplTest.java
@@ -12,6 +12,7 @@ import com.igot.cb.common.service.ContentService;
 import com.igot.cb.common.service.OutboundRequestHandlerServiceImpl;
 import com.igot.cb.common.util.CbExtAssessmentServerProperties;
 import com.igot.cb.common.util.Constants;
+import com.igot.cb.core.exception.ApplicationLogicError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -905,9 +906,7 @@ class AssessmentUtilServiceV2ImplTest {
 
     @Test
     void testValidateQumlAssessmentV3_EmptyInputs() {
-        Map<String, Object> result = utilService.validateQumlAssessmentV3(null, null, null, null);
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
+        assertThrows(ApplicationLogicError.class, () -> utilService.validateQumlAssessmentV3(null, null, null, null));
     }
 
     @Test

--- a/src/test/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2ImplTest.java
+++ b/src/test/java/com/igot/cb/assessment/service/AssessmentUtilServiceV2ImplTest.java
@@ -13,6 +13,7 @@ import com.igot.cb.common.service.OutboundRequestHandlerServiceImpl;
 import com.igot.cb.common.util.CbExtAssessmentServerProperties;
 import com.igot.cb.common.util.Constants;
 import com.igot.cb.core.exception.ApplicationLogicError;
+import com.igot.cb.core.producer.Producer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,6 +54,8 @@ class AssessmentUtilServiceV2ImplTest {
     RedisCacheMgr redisCacheMgr;
     @Mock
     ContentService contentService;
+    @Mock
+    Producer kafkaProducer;
 
     @BeforeEach
     void setUp() {
@@ -3342,6 +3345,133 @@ class AssessmentUtilServiceV2ImplTest {
         List<Map<String, Object>> resultOptions = (List<Map<String, Object>>) choices.get(Constants.OPTIONS);
         assertEquals(options, resultOptions, "Options order should be preserved when qType is not in allowed list");
     }
+
+    @Test
+    void testPublishFailedAssessmentAuditEvent_Success() throws Exception {
+        String userId = "user123";
+        String assessmentId = "assess456";
+        Map<String, Object> submitRequest = new HashMap<>();
+        submitRequest.put("key", "value");
+        String errMessage = "Some error occurred";
+        String methodName = "submitAssessmentAsync";
+        String topicName = "dev.assessment.failed.audit.error";
+        String expectedJson = "{\"userId\":\"user123\"}";
+        when(serverProperties.getAssessmentFailedAuditErrorTopic()).thenReturn(topicName);
+        when(mapper.writeValueAsString(any(Map.class))).thenReturn(expectedJson);
+        utilService.publishFailedAssessmentAuditEvent(userId, assessmentId, submitRequest, errMessage, methodName);
+        verify(mapper).writeValueAsString(any(Map.class));
+        verify(kafkaProducer).push(topicName, expectedJson);
+        verify(serverProperties).getAssessmentFailedAuditErrorTopic();
+    }
+
+    @Test
+    void testPublishFailedAssessmentAuditEvent_WithNullSubmitRequest() throws Exception {
+        String userId = "user123";
+        String assessmentId = "assess456";
+        String errMessage = "Error";
+        String methodName = "submitAssessmentAsync";
+        String topicName = "dev.assessment.failed.audit.error";
+        String expectedJson = "{\"userId\":\"user123\"}";
+        when(serverProperties.getAssessmentFailedAuditErrorTopic()).thenReturn(topicName);
+        when(mapper.writeValueAsString(any(Map.class))).thenReturn(expectedJson);
+        utilService.publishFailedAssessmentAuditEvent(userId, assessmentId, null, errMessage, methodName);
+        ArgumentCaptor<Map<String, Object>> eventCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(mapper).writeValueAsString(eventCaptor.capture());
+        Map<String, Object> capturedEvent = eventCaptor.getValue();
+        assertFalse(capturedEvent.containsKey(Constants.SUBMIT_ASSESSMENT_REQUEST),
+                "Event should not contain submitRequest when it is null");
+        verify(kafkaProducer).push(topicName, expectedJson);
+    }
+
+    @Test
+    void testPublishFailedAssessmentAuditEvent_WithEmptySubmitRequest() throws Exception {
+        String userId = "user123";
+        String assessmentId = "assess456";
+        Map<String, Object> submitRequest = new HashMap<>();
+        String errMessage = "Error";
+        String methodName = "submitAssessmentAsync";
+        String topicName = "dev.assessment.failed.audit.error";
+        String expectedJson = "{}";
+        when(serverProperties.getAssessmentFailedAuditErrorTopic()).thenReturn(topicName);
+        when(mapper.writeValueAsString(any(Map.class))).thenReturn(expectedJson);
+        utilService.publishFailedAssessmentAuditEvent(userId, assessmentId, submitRequest, errMessage, methodName);
+        ArgumentCaptor<Map<String, Object>> eventCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(mapper).writeValueAsString(eventCaptor.capture());
+        Map<String, Object> capturedEvent = eventCaptor.getValue();
+        assertFalse(capturedEvent.containsKey(Constants.SUBMIT_ASSESSMENT_REQUEST),
+                "Event should not contain submitRequest when it is empty");
+        verify(kafkaProducer).push(topicName, expectedJson);
+    }
+
+    @Test
+    void testPublishFailedAssessmentAuditEvent_EventContainsAllRequiredFields() throws Exception {
+        String userId = "user123";
+        String assessmentId = "assess456";
+        Map<String, Object> submitRequest = new HashMap<>();
+        submitRequest.put("questionId", "q1");
+        String errMessage = "Processing failed";
+        String methodName = "submitAssessmentAsyncV6";
+        String topicName = "dev.assessment.failed.audit.error";
+        when(serverProperties.getAssessmentFailedAuditErrorTopic()).thenReturn(topicName);
+        when(mapper.writeValueAsString(any(Map.class))).thenReturn("{}");
+        utilService.publishFailedAssessmentAuditEvent(userId, assessmentId, submitRequest, errMessage, methodName);
+        ArgumentCaptor<Map<String, Object>> eventCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(mapper).writeValueAsString(eventCaptor.capture());
+        Map<String, Object> capturedEvent = eventCaptor.getValue();
+        assertEquals(userId, capturedEvent.get(Constants.USER_ID));
+        assertEquals(assessmentId, capturedEvent.get(Constants.ASSESSMENT_ID_KEY));
+        assertEquals(errMessage, capturedEvent.get(Constants.ERROR_MESSAGE));
+        assertEquals(methodName, capturedEvent.get(Constants.METHOD_NAME));
+        assertEquals(Constants.FAILED, capturedEvent.get(Constants.STATUS));
+        assertNotNull(capturedEvent.get(Constants.START_TIME), "startTime should be set");
+        assertEquals(submitRequest, capturedEvent.get(Constants.SUBMIT_ASSESSMENT_REQUEST));
+    }
+
+    @Test
+    void testPublishFailedAssessmentAuditEvent_SerializationException_DoesNotThrow() throws Exception {
+        String userId = "user123";
+        String assessmentId = "assess456";
+        Map<String, Object> submitRequest = Map.of("key", "value");
+        String errMessage = "Error";
+        String methodName = "submitAssessmentAsync";
+        when(mapper.writeValueAsString(any(Map.class)))
+                .thenThrow(new com.fasterxml.jackson.core.JsonProcessingException("Serialization error") {});
+        assertDoesNotThrow(() ->
+                utilService.publishFailedAssessmentAuditEvent(userId, assessmentId, submitRequest, errMessage, methodName));
+        verify(kafkaProducer, never()).push(anyString(), anyString());
+    }
+
+    @Test
+    void testPublishFailedAssessmentAuditEvent_KafkaPushException_DoesNotThrow() throws Exception {
+        String userId = "user123";
+        String assessmentId = "assess456";
+        Map<String, Object> submitRequest = Map.of("key", "value");
+        String errMessage = "Error";
+        String methodName = "submitAssessmentAsync";
+        String topicName = "dev.assessment.failed.audit.error";
+        when(serverProperties.getAssessmentFailedAuditErrorTopic()).thenReturn(topicName);
+        when(mapper.writeValueAsString(any(Map.class))).thenReturn("{}");
+        doThrow(new RuntimeException("Kafka unavailable")).when(kafkaProducer).push(anyString(), any());
+        assertDoesNotThrow(() ->
+                utilService.publishFailedAssessmentAuditEvent(userId, assessmentId, submitRequest, errMessage, methodName));
+    }
+
+    @Test
+    void testPublishFailedAssessmentAuditEvent_StartTimeIsValidInstantFormat() throws Exception {
+        String userId = "user123";
+        String assessmentId = "assess456";
+        String errMessage = "Error";
+        String methodName = "submitAssessmentAsync";
+        String topicName = "dev.assessment.failed.audit.error";
+        when(serverProperties.getAssessmentFailedAuditErrorTopic()).thenReturn(topicName);
+        when(mapper.writeValueAsString(any(Map.class))).thenReturn("{}");
+        utilService.publishFailedAssessmentAuditEvent(userId, assessmentId, null, errMessage, methodName);
+        ArgumentCaptor<Map<String, Object>> eventCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(mapper).writeValueAsString(eventCaptor.capture());
+        Map<String, Object> capturedEvent = eventCaptor.getValue();
+        String startTime = (String) capturedEvent.get(Constants.START_TIME);
+        assertNotNull(startTime);
+        assertDoesNotThrow(() -> Instant.parse(startTime),
+                "startTime should be a valid ISO-8601 instant string");
+    }
 }
-
-


### PR DESCRIPTION
- Insert audit records to user_assessment_failed_audit table on failed assessment submissions in V4, V5, V6 APIs
- Fix validateQumlAssessmentV3 to throw instead of swallowing exceptions
- Fix String.format bugs and extract hardcoded strings to Constants