### PR TITLE
KB-12769 | Q11 | Assessment Enhancement | Enable shuffle answer options toggle in assessment creation UI

### DIFF
--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV4Impl.java
@@ -670,7 +670,7 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
             result.put(Constants.ERROR_MESSAGE, Constants.ASSESSMENT_HIERARCHY_READ_FAILED);
             return result;
         }
-        result.put(Constants.SHUFFLE, String.valueOf(getShuffleFlagFromHierarchy(assessmentAllDetail, identifierList)));
+        result.put(Constants.SHUFFLE, String.valueOf(getShuffleFlagFromHierarchy(assessmentAllDetail)));
         String primaryCategory = (String) assessmentAllDetail.get(Constants.PRIMARY_CATEGORY);
         if (Constants.PRACTICE_QUESTION_SET
                 .equalsIgnoreCase(primaryCategory)||editMode) {
@@ -1150,44 +1150,21 @@ public class AssessmentServiceV4Impl implements AssessmentServiceV4 {
     }
 
     /**
-     * Extracts the shuffle flag from the hierarchy section that contains the requested questions.
-     * Matches the requested question identifiers against each section's children to find the
-     * owning section, then returns its shuffle configuration.
+     * Extracts the shuffle flag from the current assessment hierarchy object.
+     * Returns the shuffle configuration set at the assessment level.
      *
-     * @param assessmentAllDetail the complete assessment hierarchy containing sections with shuffle config
-     * @param identifierList      the list of question identifiers requested for this call
-     * @return the shuffle flag from the matching section, or true if no matching section is found
+     * @param assessmentAllDetail the complete assessment hierarchy containing shuffle config
+     * @return the shuffle flag from the assessment object, or true if not found or cannot be cast to Boolean
      */
-    private boolean getShuffleFlagFromHierarchy(Map<String, Object> assessmentAllDetail, List<String> identifierList) {
-        List<Map<String, Object>> sections =
-                (List<Map<String, Object>>) assessmentAllDetail.get(Constants.CHILDREN);
-        if (CollectionUtils.isEmpty(sections) || CollectionUtils.isEmpty(identifierList)) {
+    private boolean getShuffleFlagFromHierarchy(Map<String, Object> assessmentAllDetail) {
+        if (MapUtils.isEmpty(assessmentAllDetail)) {
             return true;
         }
-        Set<String> requestedIds = new HashSet<>(identifierList);
-        return sections.stream()
-                .filter(section -> sectionContainsAnyQuestion(section, requestedIds))
-                .findFirst()
-                .map(section -> section.get(Constants.SHUFFLE))
-                .map(Boolean.class::cast)
-                .orElse(true);
+        Object shuffleValue = assessmentAllDetail.get(Constants.SHUFFLE);
+        if (shuffleValue instanceof Boolean) {
+            return (Boolean) shuffleValue;
+        }
+        return true;
     }
 
-    /**
-     * Checks whether a given section contains any of the requested question identifiers.
-     *
-     * @param section      a section map from the assessment hierarchy
-     * @param requestedIds the set of question identifiers to match against
-     * @return true if any child of the section matches a requested identifier, false otherwise
-     */
-    private boolean sectionContainsAnyQuestion(Map<String, Object> section, Set<String> requestedIds) {
-        List<Map<String, Object>> children =
-                (List<Map<String, Object>>) section.get(Constants.CHILDREN);
-        if (CollectionUtils.isEmpty(children)) {
-            return false;
-        }
-        return children.stream()
-                .map(child -> (String) child.get(Constants.IDENTIFIER))
-                .anyMatch(requestedIds::contains);
-    }
 }

--- a/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
+++ b/src/main/java/com/igot/cb/assessment/service/AssessmentServiceV5Impl.java
@@ -600,7 +600,7 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
             result.put(Constants.ERROR_MESSAGE, Constants.ASSESSMENT_HIERARCHY_READ_FAILED);
             return result;
         }
-        result.put(Constants.SHUFFLE, String.valueOf(getShuffleFlagFromHierarchy(assessmentAllDetail, identifierList)));
+        result.put(Constants.SHUFFLE, String.valueOf(getShuffleFlagFromHierarchy(assessmentAllDetail)));
         String primaryCategory = (String) assessmentAllDetail.get(Constants.PRIMARY_CATEGORY);
         if (Constants.PRACTICE_QUESTION_SET
                 .equalsIgnoreCase(primaryCategory)||editMode) {
@@ -1662,44 +1662,21 @@ public class AssessmentServiceV5Impl implements AssessmentServiceV5 {
 
 
     /**
-     * Extracts the shuffle flag from the hierarchy section that contains the requested questions.
-     * Matches the requested question identifiers against each section's children to find the
-     * owning section, then returns its shuffle configuration.
+     * Extracts the shuffle flag from the current assessment hierarchy object.
+     * Returns the shuffle configuration set at the assessment level.
      *
-     * @param assessmentAllDetail the complete assessment hierarchy containing sections with shuffle config
-     * @param identifierList      the list of question identifiers requested for this call
-     * @return the shuffle flag from the matching section, or true if no matching section is found
+     * @param assessmentAllDetail the complete assessment hierarchy containing shuffle config
+     * @return the shuffle flag from the assessment object, or true if not found or cannot be cast to Boolean
      */
-    private boolean getShuffleFlagFromHierarchy(Map<String, Object> assessmentAllDetail, List<String> identifierList) {
-        List<Map<String, Object>> sections =
-                (List<Map<String, Object>>) assessmentAllDetail.get(Constants.CHILDREN);
-        if (CollectionUtils.isEmpty(sections) || CollectionUtils.isEmpty(identifierList)) {
+    private boolean getShuffleFlagFromHierarchy(Map<String, Object> assessmentAllDetail) {
+        if (MapUtils.isEmpty(assessmentAllDetail)) {
             return true;
         }
-        Set<String> requestedIds = new HashSet<>(identifierList);
-        return sections.stream()
-                .filter(section -> sectionContainsAnyQuestion(section, requestedIds))
-                .findFirst()
-                .map(section -> section.get(Constants.SHUFFLE))
-                .map(Boolean.class::cast)
-                .orElse(true);
+        Object shuffleValue = assessmentAllDetail.get(Constants.SHUFFLE);
+        if (shuffleValue instanceof Boolean) {
+            return (Boolean) shuffleValue;
+        }
+        return true;
     }
 
-    /**
-     * Checks whether a given section contains any of the requested question identifiers.
-     *
-     * @param section      a section map from the assessment hierarchy
-     * @param requestedIds the set of question identifiers to match against
-     * @return true if any child of the section matches a requested identifier, false otherwise
-     */
-    private boolean sectionContainsAnyQuestion(Map<String, Object> section, Set<String> requestedIds) {
-        List<Map<String, Object>> children =
-                (List<Map<String, Object>>) section.get(Constants.CHILDREN);
-        if (CollectionUtils.isEmpty(children)) {
-            return false;
-        }
-        return children.stream()
-                .map(child -> (String) child.get(Constants.IDENTIFIER))
-                .anyMatch(requestedIds::contains);
-    }
 }

--- a/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV4ImplTest.java
+++ b/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV4ImplTest.java
@@ -999,30 +999,26 @@ class AssessmentServiceV4ImplTest {
     @Test
     void testGetShuffleFlagFromHierarchy_ShuffleTrueForMatchingSection() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.SHUFFLE, true);
         hierarchy.put(Constants.CHILDREN, List.of(
-                Map.of(Constants.SHUFFLE, true,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2"))),
-                Map.of(Constants.SHUFFLE, false,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q3"), Map.of(Constants.IDENTIFIER, "q4")))
+                Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2")
         ));
-        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 
     @Test
     void testGetShuffleFlagFromHierarchy_ShuffleFalseForMatchingSection() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.SHUFFLE, false);
         hierarchy.put(Constants.CHILDREN, List.of(
-                Map.of(Constants.SHUFFLE, true,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2"))),
-                Map.of(Constants.SHUFFLE, false,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q3"), Map.of(Constants.IDENTIFIER, "q4")))
+                Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2")
         ));
-        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q3"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertFalse(result);
     }
 
@@ -1030,9 +1026,9 @@ class AssessmentServiceV4ImplTest {
     void testGetShuffleFlagFromHierarchy_EmptySections_ReturnsTrue() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
         hierarchy.put(Constants.CHILDREN, Collections.emptyList());
-        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 
@@ -1040,21 +1036,20 @@ class AssessmentServiceV4ImplTest {
     void testGetShuffleFlagFromHierarchy_NoMatchingSection_ReturnsTrue() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
         hierarchy.put(Constants.CHILDREN, List.of(
-                Map.of(Constants.SHUFFLE, false,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1")))
+                Map.of(Constants.IDENTIFIER, "q1")
         ));
-        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q99"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 
     @Test
     void testGetShuffleFlagFromHierarchy_NullChildren_ReturnsTrue() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
-        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 
@@ -1062,12 +1057,11 @@ class AssessmentServiceV4ImplTest {
     void testGetShuffleFlagFromHierarchy_EmptyIdentifierList_ReturnsTrue() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
         hierarchy.put(Constants.CHILDREN, List.of(
-                Map.of(Constants.SHUFFLE, false,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1")))
+                Map.of(Constants.IDENTIFIER, "q1")
         ));
-        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV4Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, Collections.emptyList());
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 

--- a/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV5ImplTest.java
+++ b/src/test/java/com/igot/cb/assessment/service/AssessmentServiceV5ImplTest.java
@@ -2401,30 +2401,26 @@ class AssessmentServiceV5ImplTest {
     @Test
     void testGetShuffleFlagFromHierarchy_ShuffleTrueForMatchingSection() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.SHUFFLE, true);
         hierarchy.put(Constants.CHILDREN, List.of(
-                Map.of(Constants.SHUFFLE, true,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2"))),
-                Map.of(Constants.SHUFFLE, false,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q3"), Map.of(Constants.IDENTIFIER, "q4")))
+                Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2")
         ));
-        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 
     @Test
     void testGetShuffleFlagFromHierarchy_ShuffleFalseForMatchingSection() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
+        hierarchy.put(Constants.SHUFFLE, false);
         hierarchy.put(Constants.CHILDREN, List.of(
-                Map.of(Constants.SHUFFLE, true,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2"))),
-                Map.of(Constants.SHUFFLE, false,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q3"), Map.of(Constants.IDENTIFIER, "q4")))
+                Map.of(Constants.IDENTIFIER, "q1"), Map.of(Constants.IDENTIFIER, "q2")
         ));
-        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q3"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertFalse(result);
     }
 
@@ -2432,9 +2428,9 @@ class AssessmentServiceV5ImplTest {
     void testGetShuffleFlagFromHierarchy_EmptySections_ReturnsTrue() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
         hierarchy.put(Constants.CHILDREN, Collections.emptyList());
-        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 
@@ -2442,21 +2438,20 @@ class AssessmentServiceV5ImplTest {
     void testGetShuffleFlagFromHierarchy_NoMatchingSection_ReturnsTrue() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
         hierarchy.put(Constants.CHILDREN, List.of(
-                Map.of(Constants.SHUFFLE, false,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1")))
+                Map.of(Constants.IDENTIFIER, "q1")
         ));
-        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q99"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 
     @Test
     void testGetShuffleFlagFromHierarchy_NullChildren_ReturnsTrue() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
-        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, List.of("q1"));
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 
@@ -2464,12 +2459,11 @@ class AssessmentServiceV5ImplTest {
     void testGetShuffleFlagFromHierarchy_EmptyIdentifierList_ReturnsTrue() throws Exception {
         Map<String, Object> hierarchy = new HashMap<>();
         hierarchy.put(Constants.CHILDREN, List.of(
-                Map.of(Constants.SHUFFLE, false,
-                        Constants.CHILDREN, List.of(Map.of(Constants.IDENTIFIER, "q1")))
+                Map.of(Constants.IDENTIFIER, "q1")
         ));
-        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class, List.class);
+        Method method = AssessmentServiceV5Impl.class.getDeclaredMethod("getShuffleFlagFromHierarchy", Map.class);
         method.setAccessible(true);
-        boolean result = (boolean) method.invoke(service, hierarchy, Collections.emptyList());
+        boolean result = (boolean) method.invoke(service, hierarchy);
         assertTrue(result);
     }
 }


### PR DESCRIPTION
1. We need to check if the shuffle is enabled or not at the parent level not at the section levels.